### PR TITLE
Städtewappen nicht auf mobilen Seite anzeigen

### DIFF
--- a/_sass/_jug.scss
+++ b/_sass/_jug.scss
@@ -1,0 +1,6 @@
+@media only screen and (max-width: 480px) {
+  .desktop-image {
+    display: none;
+  }
+
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -48,5 +48,6 @@ $on-laptop:        800px;
 @import
         "base",
         "layout",
-        "syntax-highlighting"
+        "syntax-highlighting",
+        "jug"
 ;

--- a/index.html
+++ b/index.html
@@ -5,12 +5,10 @@ layout: landing
 <div class="container-fluid">
 
     <div class="row">
-        <img src="assets/main/Brunswick_Coat_of_Arms.png"
-             class="col-md-3"/>
+        <img src="assets/main/Brunswick_Coat_of_Arms.png" class="desktop-image col-md-3"/>
 
         <h1 class="col-md-6">JUG-Ostfalen</h1>
-        <img src="assets/main/Wappen_Wolfsburg.svg"
-             class="col-md-3"/>
+        <img src="assets/main/Wappen_Wolfsburg.svg" class="desktop-image col-md-3"/>
     </div>
     <div class="row">
         <div class="col-md-7">
@@ -51,5 +49,3 @@ layout: landing
         </div>
 
     </div>
-
-


### PR DESCRIPTION
Die eigentlichen Informationen werden ansonsten immer unter den Logos kommen.